### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-RPC_NODE_URL=https://eosapi.blockmatrix.network/
+RPC_NODE_URL=https://eosapi.blockmatrix.network


### PR DESCRIPTION
Unnecessary backslash breaks the API and it returns an empty string all the time.