### PR TITLE
Compatibility with PHP dotenv v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "~6.0",
-        "vlucas/phpdotenv": "^2.4",
+        "vlucas/phpdotenv": "^4.0",
         "php-curl-class/php-curl-class": "^8.1"
     },
     "require-dev": {

--- a/src/ChainFactory.php
+++ b/src/ChainFactory.php
@@ -32,7 +32,7 @@ class ChainFactory
     public function api(string $path = null, string $env = '.env', SettingsInterface $settings = null, HttpInterface $http = null): ChainController
     {
         $path = $path ?? dirname(__DIR__);
-        $settings = $settings ?? new DotenvAdapter(new Dotenv($path, $env));
+        $settings = $settings ?? new DotenvAdapter(Dotenv::createImmutable($path, $env));
         $http = $http ?? new CurlAdapter(new Curl);
 
         return new ChainController(

--- a/src/WalletFactory.php
+++ b/src/WalletFactory.php
@@ -32,7 +32,7 @@ class WalletFactory
     public function api(string $path = null, string $env = '.env', SettingsInterface $settings = null, HttpInterface $http = null): WalletController
     {
         $path = $path ?? dirname(__DIR__);
-        $settings = $settings ?? new DotenvAdapter(new Dotenv($path, $env));
+        $settings = $settings ?? new DotenvAdapter(Dotenv::createImmutable($path, $env));
         $http = $http ?? new CurlAdapter(new Curl);
 
         return new WalletController(


### PR DESCRIPTION
Add compatibility with PHP dotenv v4. V5 is out there, but Laravel still uses v4.